### PR TITLE
New commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.out
 /bin
 *.db
 tags
+.vscode

--- a/main.go
+++ b/main.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/boltdb/bolt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
@@ -14,6 +17,7 @@ import (
 )
 
 var tokenStore Repository
+var svc *dynamodb.DynamoDB
 
 var listenPort = os.Getenv("PORT")
 
@@ -65,6 +69,11 @@ func init() {
 		fmt.Printf("BoltDB initiliased (%v), bucket created!\n", tokenStore)
 	}
 
+	// DynamoDB
+	sess := session.Must(session.NewSession())
+	svc = dynamodb.New(sess, aws.NewConfig().WithRegion("eu-west-1"))
+
+	// Prometheus
 	prometheus.MustRegister(httpResponsesTotal)
 	prometheus.MustRegister(slackRequestsTotal)
 	prometheus.MustRegister(tflResponseLatencies)

--- a/routes.go
+++ b/routes.go
@@ -67,4 +67,10 @@ var r = routes{
 		"/api/slack/token/{token}",
 		withHTTPMetricsFor(slackTokenRequestHandler),
 	},
+	route{
+		"slack-subscribe-to-line",
+		[]string{http.MethodPost},
+		"/api/slack/subscribe/",
+		subscribeToLine,
+	},
 }

--- a/routes.go
+++ b/routes.go
@@ -67,10 +67,4 @@ var r = routes{
 		"/api/slack/token/{token}",
 		withHTTPMetricsFor(slackTokenRequestHandler),
 	},
-	route{
-		"slack-subscribe-to-line",
-		[]string{http.MethodPost},
-		"/api/slack/subscribe/",
-		subscribeToLine,
-	},
 }

--- a/slack_handlers_test.go
+++ b/slack_handlers_test.go
@@ -49,6 +49,7 @@ func TestSlackStatusHandler_whenCalledToRetrieveAllLines(t *testing.T) {
 
 	data := url.Values{}
 	data.Set("token", "validToken123")
+	data.Set("text", "status")
 	var req *http.Request = httptest.NewRequest(http.MethodPost, "/api/slack/tubestatus/", bytes.NewBufferString(data.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
@@ -77,7 +78,7 @@ func TestSlackStatusHandler_whenCalledToRetrieveSingleLine(t *testing.T) {
 
 	data := url.Values{}
 	data.Set("token", "validToken123")
-	data.Add("text", "bakerloo")
+	data.Add("text", "status bakerloo")
 	var req *http.Request = httptest.NewRequest(http.MethodPost, "/api/slack/tubestatus/", bytes.NewBufferString(data.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
@@ -105,7 +106,7 @@ func TestSlackStatusHandler_whenCalledToRetrieveUnexistingLine_thenReturnNotFoun
 
 	data := url.Values{}
 	data.Set("token", "validToken123")
-	data.Add("text", "unknownLine")
+	data.Add("text", "status unknownLine")
 	var req *http.Request = httptest.NewRequest(http.MethodPost, "/api/slack/tubestatus/", bytes.NewBufferString(data.Encode()))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))

--- a/slack_response.go
+++ b/slack_response.go
@@ -8,6 +8,12 @@ type slackResponse struct {
 	Attachments  []attachment `json:"attachments"`
 }
 
+func NewEphemeral() slackResponse {
+	return slackResponse{
+		ResponseType: "ephemeral",
+	}
+}
+
 type attachment struct {
 	Fallback string   `json:"fallback"`
 	Color    string   `json:"color"`

--- a/tfl-service.go
+++ b/tfl-service.go
@@ -17,14 +17,14 @@ type TubeService struct {
 func (s TubeService) GetStatusFor(lines []string) (map[string]tfl.Report, error) {
 	start := time.Now()
 	reports, err := s.Client.GetTubeStatus()
+	if err != nil {
+		return nil, err
+	}
 	go func() {
 		elapsed := time.Since(start)
 		msElapsed := elapsed / time.Millisecond
 		tflResponseLatencies.Set(float64(msElapsed))
 	}()
-	if err != nil {
-		return nil, err
-	}
 	reportsMap := tfl.ReportArrayToMap(reports)
 	if len(lines) == 0 {
 		return reportsMap, nil


### PR DESCRIPTION
Refactoring in order to allow new features.
Now the bot understands two commands, **status** and **subscribe**.

### status
`/tube status` or `/tube status bakerloo` returns the tube status respectively for all the lines or for the specified line

### subscribe
`/tube subscribe bakerloo` allows the user to specify one line per command she wants to subscribe to. This will allow other users, in the future, to query for line status by user.